### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved code formatting workflow file to enhance clarity and alignment with Ultralytics standards.  

### 📊 Key Changes  
- Adjusted a comment in the `format.yml` workflow file to enhance readability, formatting, and clarity.  
  - Changed the line: `# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license`  
  - To: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`  

### 🎯 Purpose & Impact  
- 🛠️ **Clarity:** Makes the license information cleaner and more user-friendly.  
- ⚙️ **Standards Compliance:** Aligns internal documentation formatting with existing best practices.  
- 🌐 **Minimal Impact:** No functional changes—strictly a documentation tweak for better readability.